### PR TITLE
Fix regularization loss computation

### DIFF
--- a/model/pytorch/model.py
+++ b/model/pytorch/model.py
@@ -246,4 +246,4 @@ class GTSModel(nn.Module, Seq2SeqAttrs):
                 "Total trainable parameters {}".format(count_parameters(self))
             )
 
-        return outputs, x[:, 0].clone().reshape(self.num_nodes, -1)
+        return outputs, x.softmax(-1)[:, 0].clone().reshape(self.num_nodes, -1)

--- a/model/pytorch/supervisor.py
+++ b/model/pytorch/supervisor.py
@@ -308,7 +308,7 @@ class GTSSupervisor:
                     losses.append(loss.item())
                 else:
                     loss_1 = self._compute_loss(y, output)
-                    pred = torch.sigmoid(mid_output.view(mid_output.shape[0] * mid_output.shape[1])) # Another option: use softmax.
+                    pred = mid_output.view(mid_output.shape[0] * mid_output.shape[1])
                     true_label = self.adj_mx.view(mid_output.shape[0] * mid_output.shape[1]).to(device)
                     compute_loss = torch.nn.BCELoss()
                     loss_g = compute_loss(pred, true_label)


### PR DESCRIPTION
Before this fix, the regularization loss will have (almost) no effect on the learning. This is because the adjacency matrix is generated based on the `softmax` of the edge scores, but the regularization loss is not. 

That is, the regularization loss is computed based on `sigmoid(x[:,0])`, where `x` are the scores before `softmax`. This means that the model can arbitrarily change the output of the `sigmoid` by simply adding a constant, which leaves the actual construction of the adjacency matrix via `softmax` unchanged. 

This PR fixes this issue; based on a quick run of only one epoch, the BCE loss between the learned and ground-truth adjacency matrix dropped from ~70 to ~13, indicating that the learned matrix is now much more similar to the ground-truth adjacency.